### PR TITLE
fix: Correct ReferenceError for guests in management_calendar.js

### DIFF
--- a/management_calendar.js
+++ b/management_calendar.js
@@ -134,7 +134,7 @@ function create_schedule_on_Google_Calendar(object = {}) {
       opt.location = location;
     }
     if (guests) {
-      opt.guests = guest.join(",");
+      opt.guests = guests.join(",");
       opt.sendInvites = true;
     }
     const event = cal.createEvent(
@@ -234,7 +234,7 @@ function update_schedule_on_Google_Calendar(object = {}) {
           event.setLocation(location);
         }
         if (guests) {
-          event.addGuest(guest.join(","));
+          event.addGuest(guests.join(","));
         }
         if (googleMeet) {
           Calendar.Events.patch(
@@ -324,3 +324,4 @@ const descriptions_management_calendar = {
   },
 
 };
+


### PR DESCRIPTION
The `update_schedule_on_Google_Calendar` function throws a `ReferenceError` when attempting to add guests to a calendar event.

The variable `guests` is passed into the function, but the code attempts to use an undefined variable named `guest` (singular). This commit corrects the variable name to `guests` to properly add attendees to the event.