### PR TITLE
Fix(drive): Correct ReferenceError in mimetype conversion

### DIFF
--- a/management_drive.js
+++ b/management_drive.js
@@ -264,7 +264,7 @@ function convert_mimetype_of_file_on_google_drive(object = {}) {
       const ar = new MimeTypeApp().setFileIds(fileIds).getAs({ mimeType: dstMimeType });
       const text = ar.map((e, i) => {
         if (e.toString() == "Blob") {
-          return `The mimeType of "${fileIds[i]}" was converted to "${dstMimeType}". The new file ID is "${DriveApp.createFile(blob).getId()}".`;
+          return `The mimeType of "${fileIds[i]}" was converted to "${dstMimeType}". The new file ID is "${DriveApp.createFile(e).getId()}".`;
         }
         try {
           DriveApp.getFileById(e);
@@ -756,3 +756,6 @@ const descriptions_management_drive = {
   },
   
 };
+// DriveApp.createFile(blob)
+// return `The mimeType of "${fileIds[i]}" was converted to "${dstMimeType}". The new file ID is "${DriveApp.createFile(blob).getId()}".`;
+// return `The mimeType of "${fileIds[i]}" was not converted to "${dstMimeType}". Message: ${e}`;


### PR DESCRIPTION
This PR fixes issue #11. It corrects a ReferenceError that occurs during MIME type conversion by ensuring the correct variable (`e` instead of `blob`) is used when creating the new file from a converted blob. This makes the function more robust.