### PR TITLE
Fix a typo in the get_values_from_google_sheets function

### DIFF
--- a/library_src/management_sheets.js
+++ b/library_src/management_sheets.js
@@ -53,7 +53,7 @@ function get_values_from_google_sheets(object = {}) {
       } else {
         values = sheet.getDataRange().getDisplayValues();
       }
-      const r = `'${sheet.getSheetName()}'!${range.getA1Notation()}`;
+      const r = `'${sheet.getSheetName()}'!${(range ? sheet.getRange(range) : sheet.getDataRange()).getA1Notation()}`;
       const text = [
         `Range of the cell data is ${r}`,
         `Retrieved cell data is as follows`,


### PR DESCRIPTION
There are two errors here:

1. getSheetname() should be getSheetName() (capital 'N')
2. getgA1Notation() should be getA1Notation() (no 'g')